### PR TITLE
Upgrading to 0.12

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 data "aws_iam_policy_document" "assume_role" {
-  count = "${var.create ? 1 : 0}"
+  count = var.create ? 1 : 0
 
   statement {
     effect  = "Allow"
@@ -17,14 +17,14 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 resource "aws_iam_role" "consul" {
-  count = "${var.create ? 1 : 0}"
+  count = var.create ? 1 : 0
 
   name_prefix        = "${var.name}-"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role[0].json
 }
 
 data "aws_iam_policy_document" "consul" {
-  count = "${var.create ? 1 : 0}"
+  count = var.create ? 1 : 0
 
   statement {
     sid       = "AllowSelfAssembly"
@@ -45,16 +45,17 @@ data "aws_iam_policy_document" "consul" {
 }
 
 resource "aws_iam_role_policy" "consul" {
-  count = "${var.create ? 1 : 0}"
+  count = var.create ? 1 : 0
 
   name_prefix = "${var.name}-"
-  role        = "${aws_iam_role.consul.id}"
-  policy      = "${data.aws_iam_policy_document.consul.json}"
+  role        = aws_iam_role.consul[0].id
+  policy      = data.aws_iam_policy_document.consul[0].json
 }
 
 resource "aws_iam_instance_profile" "consul" {
-  count = "${var.create ? 1 : 0}"
+  count = var.create ? 1 : 0
 
   name_prefix = "${var.name}-"
-  role        = "${aws_iam_role.consul.name}"
+  role        = aws_iam_role.consul[0].name
 }
+

--- a/output.tf
+++ b/output.tf
@@ -1,7 +1,8 @@
 output "iam_role_id" {
-  value = "${element(concat(aws_iam_role.consul.*.id, list("")), 0)}" # TODO: Workaround for issue #11210
+  value = element(concat(aws_iam_role.consul.*.id, [""]), 0) # TODO: Workaround for issue #11210
 }
 
 output "instance_profile_id" {
-  value = "${element(concat(aws_iam_instance_profile.consul.*.id, list("")), 0)}" # TODO: Workaround for issue #11210
+  value = element(concat(aws_iam_instance_profile.consul.*.id, [""]), 0) # TODO: Workaround for issue #11210
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -7,3 +7,4 @@ variable "name" {
   description = "Name for resources, defaults to \"consul-auto-join-instance-role-aws\"."
   default     = "consul-auto-join-aws"
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Used Terraform 0.12 inbuilt command to upgrade to latest version of Terraform syntax.